### PR TITLE
Custom los

### DIFF
--- a/app/R/los_distributions.R
+++ b/app/R/los_distributions.R
@@ -15,3 +15,13 @@ los_normal <- distcrete::distcrete("weibull", shape = 2, scale = 13, w = 0, inte
 
 ## los_critical for critical care
 los_critical <- distcrete::distcrete("weibull", shape = 2, scale = 10, w = 0, interval = 1)
+
+
+## customised version: user defined mean and CV
+los_gamma <- function(mean, cv) {
+  params <- epitrix::gamma_mucv2shapescale(mean, cv)
+  distcrete::distcrete("gamma",
+                       shape = params$shape,
+                       scale = params$scale,
+                       w = 0, interval = 1)
+}

--- a/app/R/los_distributions.R
+++ b/app/R/los_distributions.R
@@ -17,11 +17,22 @@ los_normal <- distcrete::distcrete("weibull", shape = 2, scale = 13, w = 0, inte
 los_critical <- distcrete::distcrete("weibull", shape = 2, scale = 10, w = 0, interval = 1)
 
 
-## customised version: user defined mean and CV
+## Customised version: user defined mean and CV
+## we want to avoid having 0 days LoS, so what we do is actually:
+## - generate a discretised Gamma with (mean - 1)
+## - add 1 to simulated LoS
 los_gamma <- function(mean, cv) {
-  params <- epitrix::gamma_mucv2shapescale(mean, cv)
-  distcrete::distcrete("gamma",
-                       shape = params$shape,
-                       scale = params$scale,
-                       w = 0, interval = 1)
+  params <- epitrix::gamma_mucv2shapescale(mean - 1, cv)
+  auxil <- distcrete::distcrete("gamma",
+                                shape = params$shape,
+                                scale = params$scale,
+                                w = 0.5, interval = 1)
+  r <- function(n) auxil$r(n) + 1
+  d <- function(x) {
+    out <- auxil$d(x - 1)
+    out[x < 1] <- 0
+    out
+  }
+
+  list(r = r, d = d)
 }

--- a/app/R/q_los.R
+++ b/app/R/q_los.R
@@ -1,0 +1,15 @@
+#' Generate quantiles of length of stay time
+#'
+#' Values are generated from a discretised gamma
+#'
+#' @author Samuel Clifford
+#'
+
+q_los <- function(mean, cv, p=c(0.025, 0.975)) {
+    
+    if (cv == 0){return(rep(x = mean, times = length(p)))} else{
+        params <- epitrix::gamma_mucv2shapescale(mean, cv)
+        stats::qgamma(p = p, shape =  params$shape, scale = params$scale)
+    }
+    
+}

--- a/app/app.R
+++ b/app/app.R
@@ -42,7 +42,7 @@ admitsPanel <- function(prefixes, tabtitle) {
       
       p("Data inputs specifying the starting point of the forecast:
         a number of new COVID-19 admissions on a given date at the location considered.
-        Reporting refers to the % of admissions notified.",
+        Reporting rate refers to the % of COVID-19 admissions reported as such.",
         style = sprintf("color:%s", annot_color)),
       dateInput(
           "admission_date",
@@ -125,7 +125,8 @@ admitsPanel <- function(prefixes, tabtitle) {
               min = 0,
               max = 2,
               value = 0.1,
-              step = .01)
+              step = .01),
+          htmlOutput("los_CI"),
       )
   ),
   mainPanel(
@@ -235,6 +236,13 @@ server <- function(input, output) {
                     cv   = input$uncertainty_doubling_time,
                     p = c(0.025, 0.975))
     sprintf("<b>Doubling time 95%% range:</b> (%0.1f, %0.1f)", q[1], q[2])
+  })
+  
+  output$los_CI <- reactive({
+    q <- q_los(mean = input$mean_los, 
+               cv   = input$cv_los,
+               p = c(0.025, 0.975))
+    sprintf("<b>LoS 95%% range:</b> (%0.1f, %0.1f)", q[1], q[2])
   })
   
   ## summary tables

--- a/app/include/info.md
+++ b/app/include/info.md
@@ -66,7 +66,7 @@ starting date and count for the forecast are required inputs.
 * **Number of simulations** to incorporate uncertainty in the doubling time and duration of stay.
   - Default: 10 simulations.
 
-
+ 
 
 ### Pre-set model parameters
 
@@ -84,7 +84,7 @@ et al., 2020</a>:
 These distributions may not be appropriate in some settings, and the user should
 take this into account when interpreting a forecast.
 
-
+Optionally, users may decide to provide custom parameters for the length of stay distribution. The custom length of stay is specified by a discretised gamma distribution whose parameters are obtained by moment matching with the mean and coefficient of variation. 
 
 ## Caveats
 


### PR DESCRIPTION
Implemented the user-custom LoS distribution, as a discretised Gamma with an offset of 1 day to ensure no LoS = 0 (but requested mean is preserved).

Currently the input is conditional on a checkbox, and if provided generates a reactive element `custom_los()` returning a list with `$r` (los random number generator) and `$d` (PMF), both including the offset. `custom_los()` is `NULL` if corresponding input box is not checked.

This can be used, but how it is integrated in the simulations depends on whether we keep 2 analyses by default, or given a XOR choice (critical or non-critical).  